### PR TITLE
イベント登録処理エラー対応

### DIFF
--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -5,9 +5,6 @@ class API < Grape::API
   rescue_from ActiveRecord::RecordNotFound do |e|
     rack_response({ error: {message: e.message} }.to_json, 404)
   end
-  # rescue_from ActiveRecord::RecordInvalid do |e|
-  #   rack_response({ error: {message: e.message} }.to_json, 400)
-  # end
 
   helpers do
     def event_params
@@ -30,16 +27,13 @@ class API < Grape::API
       requires :title, type: String, desc: "Event title."
     end
     desc "イベントを新規登録します"
-    # post "/", rabl: "event" do
     post "/" do
       @event = Event.new(event_params)
       if @event.save
         render rabl: "event"
       else
-#       @error = {:message => "saveできません"}
         @errors = @event.errors
         render rabl: "error"
-#       render rabl: "error", locals: {:message => "saveできません"}
       end
     end
   end

--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -3,17 +3,18 @@ class API < Grape::API
   formatter :json, Grape::Formatter::Rabl
 
   rescue_from ActiveRecord::RecordNotFound do |e|
-    rack_response({ error: {message: e.message} }.to_json, 200)
+    rack_response({ error: {message: e.message} }.to_json, 404)
   end
-  rescue_from ActiveRecord::RecordInvalid do |e|
-    rack_response({ error: {message: e.message} }.to_json, 200)
-  end
+  # rescue_from ActiveRecord::RecordInvalid do |e|
+  #   rack_response({ error: {message: e.message} }.to_json, 400)
+  # end
 
   helpers do
     def event_params
       ActionController::Parameters.new(params).permit(:title, :note)
     end
   end
+
   resource "events" do
     # get /api/events/:id
     params do
@@ -29,9 +30,17 @@ class API < Grape::API
       requires :title, type: String, desc: "Event title."
     end
     desc "イベントを新規登録します"
-    post "/", rabl: "event" do
+    # post "/", rabl: "event" do
+    post "/" do
       @event = Event.new(event_params)
-      @event.save!
+      if @event.save
+        render rabl: "event"
+      else
+#       @error = {:message => "saveできません"}
+        @errors = @event.errors
+        render rabl: "error"
+#       render rabl: "error", locals: {:message => "saveできません"}
+      end
     end
   end
 end

--- a/app/views/api/error.rabl
+++ b/app/views/api/error.rabl
@@ -1,5 +1,13 @@
-object @errors => :error
+object false
 
-node(:message)  do 
-  @errors.full_messages 
+messages = []
+@errors.full_messages.each do |m|
+  messages << m
 end
+
+node(:error) do
+  {
+    :message => messages
+  }
+end 
+

--- a/app/views/api/error.rabl
+++ b/app/views/api/error.rabl
@@ -1,0 +1,5 @@
+object @errors => :error
+
+node(:message)  do 
+  @errors.full_messages 
+end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe "Events", type: :request do
         end
         it "エラーメッセージの json を返す" do
           body = response.body
-          print body
           expect(body).to have_json_path('error')
           expect(body).to have_json_path('error/message')
         end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -34,9 +34,8 @@ RSpec.describe "Events", type: :request do
         event.delete 
         get "/api/events/#{event.id}.json"
       end
-      it "200 OK が返ってくる" do
-        expect(response).to be_success
-        expect(response.status).to eq(200)
+      it "400 NotFound が返ってくる" do
+        expect(response.status).to eq(404)
       end
       it "エラーメッセージのjsonを返す" do
         body = response.body
@@ -49,7 +48,7 @@ RSpec.describe "Events", type: :request do
     context "パラメタが正しい場合" do
       before do
         @params = {title: "foo", note: "bar"}
-        # @params = {event: FactoryGirl.attributes_for(:event)}
+        # @params = FactoryGirl.attributes_for(:event)
       end
 
       it "201 created が返ってくる" do
@@ -71,7 +70,23 @@ RSpec.describe "Events", type: :request do
           post "/api/events", @params
         }.to change(Event, :count).by(1)
       end
-
+    end
+    context "パラメタが正しくない場合" do
+      context "タイトルに入力がない場合" do
+        before do
+          @params = {title: "", note: ""}
+          post "/api/events", @params
+        end
+        it "HTTP STATUS は201 Created が返える" do
+          expect(response.status).to eq(201)
+        end
+        it "エラーメッセージの json を返す" do
+          body = response.body
+          print body
+          expect(body).to have_json_path('error')
+          expect(body).to have_json_path('error/message')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
確認ですが、このアプリでは、クライアントからのリクエストがサーバ側での成功・失敗に関わらず、statusは200番台で返して、クライアント側では返されたjsonの内容でリクエストの成功・失敗を判断するということでしたよね。今、showの失敗（NotFound）で404、createの失敗（RecordInvalid）で201のsutatusを返していますので、showの失敗のときのstatusを直さないといけないかなと思っています。どうでしょう？